### PR TITLE
updsted - style for height added at news-cards

### DIFF
--- a/src/components/News.jsx
+++ b/src/components/News.jsx
@@ -37,7 +37,7 @@ const News = ({ simplified }) => {
       )}
       {cryptoNews.value.map((news, i) => (
         <Col xs={24} sm={12} lg={8} key={i}>
-          <Card hoverable className="news-card">
+          <Card hoverable className="news-card" style={{ height: '100%' }}>
             <a href={news.url} target="_blank" rel="noreferrer">
               <div className="news-image-container">
                 <Title className="news-title" level={4}>{news.name}</Title>


### PR DESCRIPTION
News cards are not aligned vertically due to different title sizes. To fix this issue height property has been added.