### PR TITLE
Convert the unix timestamp into milliseconds by multiplying it by 1000

### DIFF
--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -14,7 +14,7 @@ const LineChart = ({ coinHistory, currentPrice, coinName }) => {
   }
 
   for (let i = 0; i < coinHistory?.data?.history?.length; i += 1) {
-    coinTimestamp.push(new Date(coinHistory?.data?.history[i].timestamp).toLocaleDateString());
+    coinTimestamp.push(new Date(coinHistory?.data?.history[i].timestamp * 1000).toLocaleDateString());
   }
   const data = {
     labels: coinTimestamp,


### PR DESCRIPTION
JavaScript works in milliseconds, so you'll first have to convert the UNIX timestamp from seconds to milliseconds.
var date = new Date(UNIX_Timestamp * 1000);
reference: https://stackoverflow.com/questions/847185/convert-a-unix-timestamp-to-time-in-javascript

Awesome work. Thanks a lot!