### PR TITLE
update cryptoApi.js

### DIFF
--- a/src/services/cryptoApi.js
+++ b/src/services/cryptoApi.js
@@ -22,7 +22,7 @@ export const cryptoApi = createApi({
 
     // Note: Change the coin price history endpoint from this - `coin/${coinId}/history/${timeperiod} to this - `coin/${coinId}/history?timeperiod=${timeperiod}`
     getCryptoHistory: builder.query({
-      query: ({ coinId, timeperiod }) => createRequest(`coin/${coinId}/history?timeperiod=${timeperiod}`),
+      query: ({ coinId, timeperiod }) => createRequest(`coin/${coinId}/history?timePeriod=${timeperiod}`),
     }),
 
     // Note: To access this endpoint you need premium plan


### PR DESCRIPTION
The parameter in the URL "timeperiod" is invalid and because of that, a person could not fetch currency prices within a certain period (3h,24h,1d...). By updating just the parameter, it is now possible to obtain the results for a certain timePeriod