### PR TITLE
Update Navbar.jsx

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -31,7 +31,7 @@ const Navbar = () => {
     <div className="nav-container">
       <div className="logo-container">
         <Avatar src={icon} size="large" />
-        <Typography.Title level={2} className="logo"><Link to="/">Cryptoverse</Link></Typography.Title>
+        <Typography.Title level={3} className="logo"><Link to="/">Cryptoverse</Link></Typography.Title>
         <Button className="menu-control-container" onClick={() => setActiveMenu(!activeMenu)}><MenuOutlined /></Button>
       </div>
       {activeMenu && (


### PR DESCRIPTION
level={3} is perfect for every device because when I deployed this project on my local system the navbar is overloading So, I use  level={3}
![image](https://user-images.githubusercontent.com/99037494/208869160-848b7857-f369-4245-b977-f49fdf5f462c.png)
There is perfect every size of device