### PR TITLE
Middleware issue in store.js file

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -8,4 +8,6 @@ export default configureStore({
     [cryptoApi.reducerPath]: cryptoApi.reducer,
     [cryptoNewsApi.reducerPath]: cryptoNewsApi.reducer,
   },
+  middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware().concat(cryptoApi.middleware),
 });


### PR DESCRIPTION
Middleware for RTK-Query API at reducerPath "cryptoApi" has not been added to the store.